### PR TITLE
Swap parsed parameters

### DIFF
--- a/ABCD.sol
+++ b/ABCD.sol
@@ -1200,7 +1200,7 @@ contract ABCD is ERC20, AccessControl {
         public
     {
         _setupDecimals(2);
-        _mint(msg.sender, 2500 * 10 ** 2);
+        _mint(2500 * 10 ** 2, msg.sender);
     }
     
     function mint(uint256 amount, address to) public {


### PR DESCRIPTION
Is it meant to be like this?
Here the function mint is defined like this:
```
function mint(uint256 amount, address to)
```

However when you called it shows:
```
_mint(msg.sender, 2500 * 10 ** 2);
```

Where msg.sender becomes the amount and `2500 * 10 ** 2` becomes the address.

This is probably a small mistake :)